### PR TITLE
Upgrade to latest loader-utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@ var HEADER = '/* append-loader start */';
 var FOOTER = '/* append-loader end */';
 module.exports = function(context) {
   this.cacheable && this.cacheable();
-  var query = loaderUtils.parseQuery(this.query);
+  var query = loaderUtils.getOptions(this);
   return context + HEADER + (query.content || '') + FOOTER;
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/danwang/append-loader#readme",
   "dependencies": {
-    "loader-utils": "^0.2.12"
+    "loader-utils": "^1.1.0"
   }
 }


### PR DESCRIPTION
When using loader on Webpack 3, following warning is displayed:

```sh
loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
```

It relates to [issue](https://github.com/webpack/loader-utils/issues/56) where loader-utils should be upgraded to latest version and `getOptions` method should be used instead of `parseQuery`.